### PR TITLE
Fix rebalance being called before editing nodes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,4 +26,4 @@ default = []
 bigint = ["num-bigint", "num-traits"]
 
 [dev-dependencies]
-env_logger = "0.4.3"
+env_logger = "0.6.1"

--- a/examples/with_logging.rs
+++ b/examples/with_logging.rs
@@ -9,7 +9,7 @@ use lz_diet::Diet;
 use std::borrow::Cow;
 
 pub fn main() {
-    env_logger::init().expect("failed to initialize logger");
+    env_logger::init();
 
     let mut diet = Diet::new();
 

--- a/src/diet_node.rs
+++ b/src/diet_node.rs
@@ -617,7 +617,7 @@ impl<T: AdjacentBound> DietNode<T> {
                     }
                 }
             },
-            |node, _| node.rebalance(),
+            |_node, _| (),
             |node, action, &mut (ref mut result, _)| {
                 if result.unwrap_or(false) {
                     match action {
@@ -643,7 +643,6 @@ impl<T: AdjacentBound> DietNode<T> {
             },
         );
 
-        self.rebalance();
 
         result
     }

--- a/src/diet_node.rs
+++ b/src/diet_node.rs
@@ -331,7 +331,7 @@ impl<T> DietNode<T> {
 
             Ok(WalkDirection::Left)
         } else if value >= interval.exclusive_end().borrow() {
-            debug!("walking left as value is greater than or equal to end");
+            debug!("walking right as value is greater than or equal to end");
             Ok(WalkDirection::Right)
         } else {
             debug_assert!(interval.contains(value));


### PR DESCRIPTION
These two instances could lead to the wrong node being removed